### PR TITLE
despite the documentation Time::NVtime is NV(*)() not double(*)()

### DIFF
--- a/Warp.xs
+++ b/Warp.xs
@@ -14,7 +14,7 @@ extern "C" {
 
 /* Is time() portable everywhere?  Hope so!  XXX */
 
-static double fallback_NVtime()
+static NV fallback_NVtime()
 { return time(0); }
 
 static void fallback_U2time(U32 *ret)
@@ -26,7 +26,7 @@ static void fallback_U2time(U32 *ret)
 /*-----------------*/
 
 static int    Installed=0;
-static double (*realNVtime)();
+static NV (*realNVtime)();
 static void   (*realU2time)(U32 *);
 
 static double Lost;    /** time relative to now */
@@ -42,7 +42,7 @@ static void reset_warp()
 
 /*-----------------*/
 
-static double warped_NVtime()
+static NV warped_NVtime()
 {
     double now = (*realNVtime)() - Lost;
     double delta = now - Zero;
@@ -84,7 +84,7 @@ install_time_api()
     }
     svp = hv_fetch(PL_modglobal, "Time::NVtime", 12, 0);
     if (!SvIOK(*svp)) croak("Time::NVtime isn't a function pointer");
-    realNVtime = (double(*)()) SvIV(*svp);
+    realNVtime = (NV(*)()) SvIV(*svp);
     svp = hv_fetch(PL_modglobal, "Time::U2time", 12, 0);
     if (!SvIOK(*svp)) croak("Time::U2time isn't a function pointer");
     realU2time = (void(*)(U32*)) SvIV(*svp);


### PR DESCRIPTION
the type of the Time::NVtime pointer is NV (*)() not double (*)(), as can be seen from looking at the Time::HiRes source.

On Linux x86_64 on a uselongdouble build when you replace the Time::NVtime entry with a
double (*)() pointer calls to that function end up leaving an entry on the FPU stack, eventually causing the failure seen at https://rt.perl.org/Ticket/Display.html?id=123879

This minimal commit fixes that issue and allows DBIX::Class::TimeStamp to pass its tests.